### PR TITLE
Removed the title for each post withn the body of content

### DIFF
--- a/_posts/2020-01-28-here-is-my-new-post-for-trial.markdown
+++ b/_posts/2020-01-28-here-is-my-new-post-for-trial.markdown
@@ -5,8 +5,6 @@ date: 2020-01-31
 published: true
 header_feature_image: _uploads/andrew-neel-cckf4TsHAuw-unsplash.jpg
 ---
-## Blogging - the Speakers' Corner of the 21st Century
-
 Blogging, a tale **almost** as old as the internet itself.
 In the beginning it was part of challenging the traditional gatekeeping of literature, by giving people a channel to express themselves freely. A way to make the personal _public_. Now, almost everyone on the internet read blogs, or something that is at least closely related to it. And it has in a few years managed to become a fundamental part of the online world.
 

--- a/_posts/2020-02-08-how-the-digital-age-has-changed-book-covers.markdown
+++ b/_posts/2020-02-08-how-the-digital-age-has-changed-book-covers.markdown
@@ -7,7 +7,6 @@ header_feature_image: _uploads/veroniki-thetis-chelioti-_LzFAUyqVtg-unsplash.jpg
 caption:
 tags:    # use [tag1,tag2]
 ---
-## How the Digital Age Has Changed Book Covers
 
 Books, described by David Pearson, are artefacts and time capsules preserving a certain kind of human knowledge (Ojeda, Lommen, 2016: 182). And for a long time, the _cover_ of the book has functioned as a gateway into this knowledge. A vital marketing tool, and a part of communicating the book’s identity. But, like many traditional media, the book and its cover has been immensely impacted with the rise of the digital age. The turn to digital has not only introduced a new platform, but also changed the way book covers are produced, how they look, and how they function.
 

--- a/_posts/2020-02-13-metadata-the-key-for-discovering-books.markdown
+++ b/_posts/2020-02-13-metadata-the-key-for-discovering-books.markdown
@@ -7,7 +7,6 @@ header_feature_image: _uploads/franki-chamaki-1K6IQsQbizI-unsplash.jpg
 caption:
 tags:   # use [tag1,tag2]
 ---
-## Metadata - the Key for Discovering Books
 
 Metadata is nowadays one of the most important elements for discovering books. But what is it? And what does it mean for publishers?
 
@@ -16,7 +15,7 @@ Metadata is nowadays one of the most important elements for discovering books. B
 Photo credit: Franki Chamaki on Unsplash
 
 
-The word meta means ‘about’, making the literal definition of metadata as “data _about_ data” (Lubas, Jackson and Schneider, 2013). And essentially that’s what it is. Metadata provides context to digital resources (data).  
+The word meta means ‘about’, making the literal definition of metadata as “data _about_ data” (Lubas, Jackson and Schneider, 2013). And essentially that’s what it is. Metadata provides context to digital resources (data).
 
 To paint a picture. Let's say you saw a book in a bookshop and wanted to know more about it. When you get home you go online, click on the search engine to type in its title – only to realize that you forgot what it was called. The only thing you can remember is what the cover looked like or what kind of genre it was. This is where metadata comes into the picture.
 

--- a/_posts/2020-02-26-a-brief-look-at-the-development-of-html.markdown
+++ b/_posts/2020-02-26-a-brief-look-at-the-development-of-html.markdown
@@ -7,9 +7,8 @@ header_feature_image: _uploads/four-letter-tiles-1591061.jpg
 caption:
 tags:    # use [tag1,tag2]
 ---
-## A Brief Look at the Development of HTML
 
-HTML is everywhere. Since its creation it has become a major component of the web. Every website relies on it. Let’s take a brief look at its development.  
+HTML is everywhere. Since its creation it has become a major component of the web. Every website relies on it. Let’s take a brief look at its development.
 
 [![html](/_uploads/four-letter-tiles-1591061.jpg)](/_uploads/four-letter-tiles-1591061.jpg)
 Photo credit: Pixabay from Pexels

--- a/_posts/2020-03-02-the-importance-of-user-testing-products.markdown
+++ b/_posts/2020-03-02-the-importance-of-user-testing-products.markdown
@@ -7,7 +7,6 @@ header_feature_image: _uploads/david-travis-WC6MJ0kRzGw-unsplash.jpg
 caption:
 tags:    # use [tag1,tag2]
 ---
-## The Importance of User-testing Products
 
 When developing products and services, many companies conduct user research. It is considered to be one of the most important aspects of making a business successful. But what exactly is it?
 
@@ -34,11 +33,11 @@ The benefits of user-testing are the same for both physical and digital products
 
 1. It helps a company save time (Praxent, 2019). If a problem is discovered early in the developing process, there is still time to fix it. Equally, the user reactions can even help in understanding whether or not the product is feasible to complete.
 2. By saving time on product development a company also saves money (ibid). For instance, in the case of identifying what product features to either keep or get rid of.
-3. It helps in understanding product desirability (ibid). If users find value in the product, this can be an indicator of the success and appeal that the product might face in the marketplace.  
+3. It helps in understanding product desirability (ibid). If users find value in the product, this can be an indicator of the success and appeal that the product might face in the marketplace.
 
 As a result of the benefits of user-testing, product developers are able have in-depth research and answer important questions that surrounds the product, like: what will the product do; how should it look; how long will it take to make it; and how much will it cost us? (Praxent, 2019).
 
-Conclusively, user-testing is a valuable method that can impact the design of the product or service; the product development process of a business; and the product or service’s success.   
+Conclusively, user-testing is a valuable method that can impact the design of the product or service; the product development process of a business; and the product or service’s success.
 
 
 **References:**

--- a/_posts/2020-03-15-the-rise-of-audiobooks.markdown
+++ b/_posts/2020-03-15-the-rise-of-audiobooks.markdown
@@ -7,14 +7,14 @@ header_feature_image: _uploads/Utennavn.png
 caption:
 tags:    # use [tag1,tag2]
 ---
-## The Rise of Audiobooks  
+ 
 
-In 2005, a Publisher's Weekly article claimed that "downloadable audiobooks are poised to transform the market" (Cheever, p. 26) Back then, audiobooks only made up around 4-10% of the total book market, but was at the time experiencing a slight increase in sales (ibid). Today, it is the fastest growing sector in digital publishing. Turns out they were right.  
+In 2005, a Publisher's Weekly article claimed that "downloadable audiobooks are poised to transform the market" (Cheever, p. 26) Back then, audiobooks only made up around 4-10% of the total book market, but was at the time experiencing a slight increase in sales (ibid). Today, it is the fastest growing sector in digital publishing. Turns out they were right.
 
 [![Audiobooks](/_uploads/Utennavn.png)](/_uploads/Utennavn.png)
 Photo credit: Lena Kudryavtseva on Unsplash
 
-Audiobooks have come a long way since the time of cassettes and CDs. The sector is still considered to be the baby in the industry (compared to its physical peers), but is nonetheless growing fast. While the sales of physical books have seen a decline within the last few years, the audiobook format has increased in popularity. For example, in 2018, US audiobooks had a 27.3% increase in unit sales (Anderson, 2019).  
+Audiobooks have come a long way since the time of cassettes and CDs. The sector is still considered to be the baby in the industry (compared to its physical peers), but is nonetheless growing fast. While the sales of physical books have seen a decline within the last few years, the audiobook format has increased in popularity. For example, in 2018, US audiobooks had a 27.3% increase in unit sales (Anderson, 2019).
 
 Due to the surge in sales, publishers have started to invest some serious money into the production of audiobooks. To set an example – for the production of George Saunders’ successful novel Lincoln in the Bardo there were 166 narrators featured on it (Thorp, 2020). As more and more people are purchasing audiobooks, publishers see more potential in investing and being creative with them.
 

--- a/_posts/2020-03-22-what-are-the-different-e-book-devices-and-how-do-they-differ.markdown
+++ b/_posts/2020-03-22-what-are-the-different-e-book-devices-and-how-do-they-differ.markdown
@@ -7,7 +7,6 @@ header_feature_image: _uploads/ereader.jpg
 caption:
 tags:    # use [tag1,tag2]
 ---
-## What Are the Different E-Book Devices and How Do They Differ?
 
 Ever since its introduction, the e-book has become a viable and increasingly common way for reading books. Many people nowadays have either switched entirely to reading digital books, or reading them alongside print ones. For these readers today there are plentiful of choices out there for both e-reading devices and tablets. All with either very different or minor variations and features.
 
@@ -45,7 +44,7 @@ They also differ in **screen types** and **display**. Here, e-readers are way be
 
 In terms of **functions**, you have more flexibility with tablets than with e-readers. This is all thanks to apps. By storing the e-books on tablet apps; you get ‘cross-platform support’ (Falcone, 2012). This is useful if you want to access your books on any other device that you might have – tablet, PC or your phone. In addition, with tablets you can do more than just read. As a multimedia device, you can browse the web, play games, watch Netflix, and so on. E-reading devices have a singular purpose, and that is for reading books.
 
-In considering which device to choose from, you must know what it is that you are looking for and which factors you redeem most important.  
+In considering which device to choose from, you must know what it is that you are looking for and which factors you redeem most important.
 
 
 **References**:

--- a/_posts/2020-03-28-typeface-variation-–-function-and-aesthetics.markdown
+++ b/_posts/2020-03-28-typeface-variation-–-function-and-aesthetics.markdown
@@ -7,7 +7,6 @@ header_feature_image: _uploads/alexander-andrews-zw07kVDaHPw-unsplash.jpg
 caption:
 tags:    # use [tag1,tag2]
 ---
-## Typeface Variation – Function and Aesthetics
 
 When reading a document, readers perceive not only the overall text but also the features within it, such as the typography. Used properly, typography can have an immense impact on the success of a design. For this reason, it is at the centre of design practice.
 
@@ -46,7 +45,7 @@ Script is a “hand-writing” style typeface. The script fonts are immediately 
 The decorative fonts are generally more unique and appealing than the other typeface fonts. Known for their emphasize on originality, the decorative fonts allow more flexibility to designers as they are often tailored to fit a certain industry or need. They are rarely used for longer pieces of writing, and work best for use in logos. For this reason, decorative fonts are often used by companies that wish to communicate their specific brand (tailorbrands.com, n.d.)
 
 
-Ultimately, through selecting typefaces a designer can convey different messages, emotions or ideas. It is one of the most fundamental factors in communicating the meaning of a design (Marshall, Meachem, 2012). And if there is a mismatch between your typeface and message, the consequence can result in a visual disconnect for the readers, causing your design to have less impact.  
+Ultimately, through selecting typefaces a designer can convey different messages, emotions or ideas. It is one of the most fundamental factors in communicating the meaning of a design (Marshall, Meachem, 2012). And if there is a mismatch between your typeface and message, the consequence can result in a visual disconnect for the readers, causing your design to have less impact.
 
 
 **References:**

--- a/_posts/2020-04-20-what-makes-a-good-book-cover.markdown
+++ b/_posts/2020-04-20-what-makes-a-good-book-cover.markdown
@@ -7,7 +7,6 @@ header_feature_image: _uploads/Utennavn.jpg
 caption:
 tags:    # use [tag1,tag2]
 ---
-## What Makes a Good Book Cover?
 
 There is an old saying that goes: “Don’t judge a book by its cover”. It is a meaningful message to bring into your everyday life; of not basing your judgements on appearances only. But in the case of books? It could not be more out of place.
 

--- a/_posts/2020-04-29-the-many-faces-of-book-covers.markdown
+++ b/_posts/2020-04-29-the-many-faces-of-book-covers.markdown
@@ -7,7 +7,6 @@ header_feature_image: _uploads/annie-spratt-XKVOEJSnVEY-unsplash.jpg
 caption:
 tags:    # use [tag1,tag2]
 ---
-## The Many Faces of Book Covers
 
 The cover is the face of the book. It gives insight into what you can expect from the content. Like people, book covers also have many different faces. When a book gets translated into other languages, the cover often goes through a similar process. Based on where in the world it gets published, the translated book cover can look very different from the original one. Why is this often the case?
 


### PR DESCRIPTION
Removed the title for each post withn the body of content because this then repeats the title. You only need the title in the metadata. You need the first paragraph to show on the home page listing. This was different for the recipes site because the code removed the second title - we needed the title for the future use in the eBook (we never got to that!)